### PR TITLE
Add lower bound on bytestring

### DIFF
--- a/double-conversion.cabal
+++ b/double-conversion.cabal
@@ -106,7 +106,7 @@ library
 
   build-depends:
     base == 4.*,
-    bytestring,
+    bytestring >= 0.10.12.0,
     ghc-prim,
     text >= 0.11.0.8 && < 2.0
 


### PR DESCRIPTION
With older versions of bytestring I get:

```
Data/Double/Conversion/Internal/ByteStringBuilder.hs:24:60: error:
    Module
    ‘Data.ByteString.Builder.Prim.Internal’
    does not export
    ‘boundedPrim’
   |
24 | import Data.ByteString.Builder.Prim.Internal (BoundedPrim, boundedPrim)
   |                                                            ^^^^^^^^^^^
```